### PR TITLE
Bugfix regarding setup of deployment

### DIFF
--- a/_layout/head.html
+++ b/_layout/head.html
@@ -9,7 +9,7 @@
     <style>
     @font-face {
       font-family: JuliaMono-Regular;
-      src: url("/JuliaTutorialsTemplate/{{artifact JuliaMono juliamono-0.042 webfonts JuliaMono-Regular.woff2}}");
+      src: url("/learn.jl/{{artifact JuliaMono juliamono-0.042 webfonts JuliaMono-Regular.woff2}}");
     }
     </style>
 

--- a/config.md
+++ b/config.md
@@ -8,7 +8,7 @@ mintoclevel = 2
 # Base files such as LICENSE.md and README.md are ignored by default.
 ignore = ["node_modules/"]
 
-prepath = "JuliaTutorialsTemplate"
+prepath = "learn.jl"
 
 # RSS (the website_{title, descr, url} must be defined to get RSS)
 generate_rss = false


### PR DESCRIPTION
We had to replace two references to the original repo (for the template) by the name of our repo (learn.jl)